### PR TITLE
Don't attach to shadow

### DIFF
--- a/source/javascripts/db2cp.js
+++ b/source/javascripts/db2cp.js
@@ -2,10 +2,6 @@
   class DribbbleToCodepen extends HTMLElement {
     constructor() {
       super();
-
-      var shadow = this.attachShadow({
-        mode: 'open'
-      });
     }
   }
 


### PR DESCRIPTION
This means that the `dribbble-to-codepen` won't be hidden from the regular dom, but that doesn't really matter, since it now works in browsers without transpiling.